### PR TITLE
patch codespace URL and don't recreate Web application

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,15 +17,15 @@
   "onCreateCommand": {
     "Setup cachix": "echo \"trusted-users = root vscode\" | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon; cachix use cachix; cachix use digitallyinduced;",
     "Setup direnv": "sudo apt install direnv; echo 'eval \"$(direnv hook bash)\"' >> ~/.bashrc",
-    "Set IHP BASEURL": "echo 'export IHP_BASEURL=$(if [ -n \"${CODESPACE_NAME}\" ]; then echo \"https://${CODESPACE_NAME}-8000.preview.app.github.dev\"; else echo \"http://localhost:8000\"; fi)' >> ~/.bashrc",
-    "Set IHP IDE BASEURL": "echo 'export IHP_IDE_BASEURL=$(if [ -n \"${CODESPACE_NAME}\" ]; then echo \"https://${CODESPACE_NAME}-8001.preview.app.github.dev\"; else echo \"http://localhost:8001\"; fi)' >> ~/.bashrc",
+    "Set IHP BASEURL": "echo 'export IHP_BASEURL=$(if [ -n \"${CODESPACE_NAME}\" ]; then echo \"https://${CODESPACE_NAME}-8000.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; else echo \"http://localhost:8000\"; fi)' >> ~/.bashrc",
+    "Set IHP IDE BASEURL": "echo 'export IHP_IDE_BASEURL=$(if [ -n \"${CODESPACE_NAME}\" ]; then echo \"https://${CODESPACE_NAME}-8001.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}\"; else echo \"http://localhost:8001\"; fi)' >> ~/.bashrc",
     "Fix nix Permissions": "sudo apt install acl; sudo setfacl -k /tmp",
     "Allow direnv": "mkdir -p ~/.config/direnv; touch ~/.config/direnv/direnv.toml; echo \"[whitelist]\nprefix = ['/workspaces/']\" >> ~/.config/direnv/direnv.toml"
   },
 
   "postCreateCommand": {
     // Credits to https://github.com/gitpod-samples/template-ihp/blob/e3fe7012621ab57657c59511b2fe0bc615d5186d/.gitpod.yml#L14
-    "Setup IHP": "sudo /usr/local/share/nix-entrypoint.sh; ( if [ ! -e \"Main.hs\" ]; then rm -rf /tmp/ihp-boilerplate; git clone \"https:\/\/github.com/digitallyinduced/ihp-boilerplate.git\" /tmp/ihp-boilerplate; rm -rf /tmp/ihp-boilerplate/.git; cp -r /tmp/ihp-boilerplate/. .; fi) && git add . && nix develop --accept-flake-config --impure --command make -s all; nix develop --accept-flake-config --impure --command new-application Web"
+    "Setup IHP": "sudo /usr/local/share/nix-entrypoint.sh; ( if [ ! -e \"Main.hs\" ]; then rm -rf /tmp/ihp-boilerplate; git clone \"https:\/\/github.com/digitallyinduced/ihp-boilerplate.git\" /tmp/ihp-boilerplate; rm -rf /tmp/ihp-boilerplate/.git; cp -r /tmp/ihp-boilerplate/. .; fi) && git add . && nix develop --accept-flake-config --impure --command make -s all; if [ ! -d \"Web\" ]; then (nix develop --accept-flake-config --impure --command new-application Web) fi"
   },
 
   "containerEnv": {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an IHP template configured to run on GitHub Codespaces. It can also be u
 
 ## Instructions
 1. Create a repo from this template.
-2. Run it in Codespaces / Devcontainer.
+2. Run it in Codespaces / Devcontainers.
 3. Wait for the initial setup to complete. This will take a few minutes and will use two bash windows, one of which will close when it's done. The other should be a blank terminal when it's done.
 4. Run `devenv up` to start the server.
 5. Have fun with IHP! :)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ placing it in `.devcontainer/devcontainer.json`. Then follow the above instructi
 
 ## Updates
 Sometimes GitHub updates Codespaces or their base container image, which may break this config. Please check here regularly for 
-updates and post an issue if you have problems running a Codespace/Devcontainer. To update, simply copy the new `devcontainer.json` 
-to your project, and then rebuild the container or recreate your Codespace/devcontainer entirely.
+updates and post an issue if you have problems running a Codespace / Devcontainer. To update, simply copy the new `devcontainer.json` 
+to your project, and then rebuild the container or recreate your Codespace / Devcontainer entirely.
 
 See also [ihp.digitallyinduced.com](https://ihp.digitallyinduced.com/)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This is an IHP template configured to run on GitHub Codespaces. It can also be used to run on [VSCode Devcontainers](https://code.visualstudio.com/docs/devcontainers/containers). 
 
-To add support to an existing IHP project, simply copy the [devcontainer configuration](.devcontainer/devcontainer.json) to your project.
+## Instructions
+1. Create a repo from this template.
+2. Run it in Codespaces / Devcontainer.
+3. Wait for the initial setup to complete. This will take a few minutes and will use two bash windows, one of which will close when it's done. The other should be a blank terminal when it's done.
+4. Run `devenv up` to start the server.
+5. Have fun with IHP! :)
+
+## Adding support to an older IHP project
+To add support to an existing IHP project, simply copy the [devcontainer configuration](.devcontainer/devcontainer.json) to your project, 
+placing it in `.devcontainer/devcontainer.json`. Then follow the above instructions.
+
+## Updates
+Sometimes GitHub updates Codespaces or their base container image, which may break this config. Please check here regularly for 
+updates and post an issue if you have problems running a Codespace/Devcontainer. To update, simply copy the new `devcontainer.json` 
+to your project, and then rebuild the container or recreate your Codespace/devcontainer entirely.
 
 See also [ihp.digitallyinduced.com](https://ihp.digitallyinduced.com/)


### PR DESCRIPTION
This PR:
- Fixes IHP in Codespaces according to the following change made by GitHub: https://github.blog/changelog/2023-07-14-codespaces-port-forwarding-domain-name-updates/
- Fixes a bug where creating a new Codespace would overwrite an existing `Web` application, if one exists. I think this was introduced in the new IHP version (never used to happen!) but for now we'll put in a band-aid solution. Let's track https://github.com/digitallyinduced/ihp/issues/1794 for a fix to this, and we may be able to remove this (though it's not a huge deal to leave in, really)